### PR TITLE
Feature Action Handles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /public/.sass-cache/
 /tests/TestConfig.php
 /vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build/
 /.idea/
 /public/.sass-cache/
 /tests/TestConfig.php

--- a/config/con-layout.global.php.dist
+++ b/config/con-layout.global.php.dist
@@ -41,11 +41,28 @@ return [
         ],
         'default_area' => LayoutUpdateListener::AREA_DEFAULT,
         /**
-         * exclude segments of controller namespace
+         * Array of controller namespace -> action handle mappings. Assuming that the setting
+         * 'prefer_route_match_controller' is set to 'false' and the controller fully qualified
+         * class name is 'Foo\Bar\Controller\IndexController::test'.
+         * 
+         *  'controller_map' => [
+         *      'Foo\Bar' => 'custom'
+         *  ]
+         * 
+         * The action handles injected would be:
+         * 
+         *   'default'
+         *   'custom'
+         *   'custom-index',
+         *   'custom-index-test'
          */
-        'exclude_action_handle_segments' => [
-            'Controller'
+        'controller_map' => [
+            
         ],
+        /**
+         * Whether to force the use of the route match controller param.
+         */
+        'prefer_route_match_controller' => false,
         /**
          * shows block hints
          *

--- a/config/con-layout.global.php.dist
+++ b/config/con-layout.global.php.dist
@@ -43,18 +43,25 @@ return [
         /**
          * Array of controller namespace -> action handle mappings. Assuming that the setting
          * 'prefer_route_match_controller' is set to 'false' and the controller fully qualified
-         * class name is 'Foo\Bar\Controller\IndexController::test'.
+         * class name is 'FooBar\Controller\IndexController::test'.
          * 
          *  'controller_map' => [
-         *      'Foo\Bar' => 'custom'
+         *      'FooBar' => 'custom-handle'
          *  ]
          * 
          * The action handles injected would be:
          * 
-         *   'default'
-         *   'custom'
-         *   'custom-index',
-         *   'custom-index-test'
+         *  'default'
+         *  'custom-handle'
+         *  'custom-handle/index'
+         *  'custom-handle/index/test'
+         *
+         * Instead of:
+         *
+         *  'default'
+         *  'foo-bar'
+         *  'foo-bar/index'
+         *  'foo-bar/index/test'
          */
         'controller_map' => [
             

--- a/src/ConLayout/Listener/ActionHandlesListener.php
+++ b/src/ConLayout/Listener/ActionHandlesListener.php
@@ -57,7 +57,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Retrieve the layout updater instance.
-     * 
+     *
      * @return LayoutUpdaterInterface
      */
     public function getUpdater()
@@ -67,7 +67,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Set the layout updater instance.
-     * 
+     *
      * @param LayoutUpdaterInterface $updater
      * @return ActionHandlesListener
      */
@@ -80,7 +80,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Retrieve an array of controller namespace -> action handle mappings.
-     * 
+     *
      * @return array
      */
     public function getControllerMap()
@@ -90,7 +90,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Set an array of controller namespace -> action handle mappings.
-     * 
+     *
      * @param array $controllerMap
      * @return ActionHandlesListener
      */
@@ -104,7 +104,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Whether to force the use of the route match controller param.
-     * 
+     *
      * @return boolean
      */
     public function isPreferRouteMatchController()
@@ -114,7 +114,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     
     /**
      * Set whether to force the use of the route match controller param.
-     * 
+     *
      * @param boolean $preferRouteMatchController
      * @return ActionHandlesListener
      */
@@ -147,8 +147,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     {
         $handles = $this->getActionHandles($event);
         
-        foreach ($handles as $handle)
-        {
+        foreach ($handles as $handle) {
             $this->updater->addHandle($handle);
         }
     }
@@ -219,8 +218,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
         $previousHandle = '';
         $handleParts = explode(self::HANDLE_SEPARATOR, $actionHandle);
         
-        foreach ($handleParts as $index => $name)
-        {
+        foreach ($handleParts as $index => $name) {
             $actionHandles[] = new Handle($previousHandle.$name, $priority);
             $priority += 10;
             $previousHandle .= $name.self::HANDLE_SEPARATOR;
@@ -242,8 +240,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
         }
         
         foreach ($this->controllerMap as $namespace => $replacement) {
-            if (
-                false == $replacement
+            if (false == $replacement
                 || !($controller === $namespace || strpos($controller, $namespace . '\\') === 0)
             ) {
                 continue;

--- a/src/ConLayout/Listener/ActionHandlesListener.php
+++ b/src/ConLayout/Listener/ActionHandlesListener.php
@@ -7,8 +7,9 @@ use Zend\EventManager\EventInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\EventManager\ListenerAggregateTrait;
+use Zend\Filter\Word\CamelCaseToDash;
+use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
-use Zend\Mvc\Router\RouteMatch;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
@@ -16,92 +17,326 @@ use Zend\ServiceManager\ServiceLocatorAwareTrait;
  * @package ConLayout
  * @author Cornelius Adams (conlabz GmbH) <cornelius.adams@conlabz.de>
  */
-class ActionHandlesListener implements
-    ListenerAggregateInterface,
-    ServiceLocatorAwareInterface
+class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocatorAwareInterface
 {
     use ListenerAggregateTrait;
     use ServiceLocatorAwareTrait;
-
+    
     /**
+     * Character used to separate parts of a controller name.
+     */
+    const HANDLE_SEPARATOR = '-';
+    
+    /**
+     * Layout updater instance.
      *
      * @var LayoutUpdaterInterface
      */
     protected $updater;
-
+    
     /**
+     * Array of controller namespace -> action handle mappings.
      *
      * @var array
      */
-    protected $excludeSegments = [];
-
+    protected $controllerMap = [];
+    
     /**
+     * Flag to force the use of the route match controller param.
      *
-     * @param LayoutUpdaterInterface $updater
+     * @var boolean
      */
-    public function __construct(
-        LayoutUpdaterInterface $updater,
-        array $excludeSegments = ['Controller']
-    ) {
-        $this->updater = $updater;
-        $this->excludeSegments = $excludeSegments;
-    }
-
+    protected $preferRouteMatchController = false;
+    
     /**
+     * Inflector used to normalize names for use as action handles.
+     *
+     * @var CamelCaseToDash
+     */
+    protected $inflector;
+    
+    /**
+     * Retrieve the layout updater instance.
+     * 
+     * @return LayoutUpdaterInterface
+     */
+    public function getUpdater()
+    {
+        return $this->updater;
+    }
+    
+    /**
+     * Set the layout updater instance.
+     * 
+     * @param LayoutUpdaterInterface $updater
+     * @return ActionHandlesListener
+     */
+    public function setUpdater(LayoutUpdaterInterface $updater)
+    {
+        $this->updater = $updater;
+        
+        return $this;
+    }
+    
+    /**
+     * Retrieve an array of controller namespace -> action handle mappings.
+     * 
+     * @return array
+     */
+    public function getControllerMap()
+    {
+        return $this->controllerMap;
+    }
+    
+    /**
+     * Set an array of controller namespace -> action handle mappings.
+     * 
+     * @param array $controllerMap
+     * @return ActionHandlesListener
+     */
+    public function setControllerMap(array $controllerMap)
+    {
+        krsort($controllerMap);
+        $this->controllerMap = $controllerMap;
+        
+        return $this;
+    }
+    
+    /**
+     * Whether to force the use of the route match controller param.
+     * 
+     * @return boolean
+     */
+    public function isPreferRouteMatchController()
+    {
+        return $this->preferRouteMatchController;
+    }
+    
+    /**
+     * Set whether to force the use of the route match controller param.
+     * 
+     * @param boolean $preferRouteMatchController
+     * @return ActionHandlesListener
+     */
+    public function setPreferRouteMatchController($preferRouteMatchController)
+    {
+        $this->preferRouteMatchController = (boolean) $preferRouteMatchController;
+        
+        return $this;
+    }
+    
+    /**
+     * Attach event listeners for retrieving action handles.
      *
      * @param EventManagerInterface $events
+     * @return void
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'addActionHandles'], 1000);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'addErrorHandle'], 100);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'injectActionHandles'], 1000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'injectErrorHandle'], 100);
     }
-
+    
     /**
+     * Callback handler invoked when the dispatch event is triggered.
      *
      * @param EventInterface $event
+     * @return void
      */
-    public function addActionHandles(EventInterface $event)
+    public function injectActionHandles(EventInterface $event)
     {
-        $routeMatch = $event->getRouteMatch();
-        $handles = $this->getActionHandles($routeMatch);
-        foreach ($handles as $handle) {
+        $handles = $this->getActionHandles($event);
+        
+        foreach ($handles as $handle)
+        {
             $this->updater->addHandle($handle);
         }
     }
-
+    
     /**
+     * Callback handler invoked when the dispatch error event is triggered.
      *
      * @param EventInterface $event
+     * @return void
      */
-    public function addErrorHandle(EventInterface $event)
+    public function injectErrorHandle(EventInterface $event)
     {
-        $this->updater->addHandle(new Handle($event->getError(), 15));
+        $this->updater->addHandle(new Handle($event->getError(), 666));
     }
-
+    
     /**
+     * Retrieve the action handles from the matched route.
      *
-     * @param RouteMatch $routeMatch
+     * @param EventInterface $event
      * @return array
      */
-    private function getActionHandles(RouteMatch $routeMatch)
+    protected function getActionHandles(EventInterface $event)
     {
-        $controller = $routeMatch->getParam('controller');
-        $action = $routeMatch->getParam('action');
-        $actionHandles = [];
-        $namespaceSegments = array_values(array_diff(
-            explode('\\', $controller),
-            $this->excludeSegments
-        ));
-        $count = count($namespaceSegments);
-        for ($i = 0; $i < $count; $i++) {
-            for ($j = 0; $j <= $i; $j++) {
-                $actionHandles[$i][] = $namespaceSegments[$j];
-            }
-            $handleName = strtolower(implode('-', $actionHandles[$i]));
-            $actionHandles[$i] = new Handle($handleName, $j);
+        /* @var $routeMatch MvcEvent */
+        $routeMatch = $event->getRouteMatch();
+        $controller = $event->getTarget();
+        
+        if (is_object($controller)) {
+            $controller = get_class($controller);
         }
-        $actionHandles[] = new Handle($handleName . '-' . $action, $j + 1);
+        
+        $routeMatchController = $routeMatch->getParam('controller', '');
+        if (!$controller || ($this->preferRouteMatchController && $routeMatchController)) {
+            $controller = $routeMatchController;
+        }
+        
+        $actionHandle = $this->mapController($controller);
+        if (!$actionHandle) {
+            $module     = $this->deriveModuleNamespace($controller);
+            
+            if ($namespace = $routeMatch->getParam(ModuleRouteListener::MODULE_NAMESPACE)) {
+                $controllerSubNs = $this->deriveControllerSubNamespace($namespace);
+                if (!empty($controllerSubNs)) {
+                    if (!empty($module)) {
+                        $module .= self::HANDLE_SEPARATOR . $controllerSubNs;
+                    } else {
+                        $module = $controllerSubNs;
+                    }
+                }
+            }
+            
+            $controller = $this->deriveControllerClass($controller);
+            $actionHandle = $this->inflectName($module);
+            
+            if (!empty($actionHandle)) {
+                $actionHandle .= self::HANDLE_SEPARATOR;
+            }
+            $actionHandle .= $this->inflectName($controller);
+        }
+        
+        $action = $routeMatch->getParam('action');
+        if (null !== $action) {
+            $actionHandle .= self::HANDLE_SEPARATOR . $this->inflectName($action);
+        }
+        
+        $priority = 10;
+        $actionHandles = [];
+        $previousHandle = '';
+        $handleParts = explode(self::HANDLE_SEPARATOR, $actionHandle);
+        
+        foreach ($handleParts as $index => $name)
+        {
+            $actionHandles[] = new Handle($previousHandle.$name, $priority);
+            $priority += 10;
+            $previousHandle .= $name.self::HANDLE_SEPARATOR;
+        }
+        
         return $actionHandles;
+    }
+    
+    /**
+     * Map a controller to action handle if a controller namespace is white-listed or mapped.
+     *
+     * @param string $controller
+     * @return string|false
+     */
+    public function mapController($controller)
+    {
+        if (!is_string($controller)) {
+            return false;
+        }
+        
+        foreach ($this->controllerMap as $namespace => $replacement) {
+            if (
+                false == $replacement
+                || !($controller === $namespace || strpos($controller, $namespace . '\\') === 0)
+            ) {
+                continue;
+            }
+            
+            $map = '';
+            
+            if (is_string($replacement)) {
+                $map = rtrim($replacement, self::HANDLE_SEPARATOR) . self::HANDLE_SEPARATOR;
+                $controller = substr($controller, strlen($namespace) + 1) ?: '';
+            }
+            
+            $parts = explode('\\', $controller);
+            array_pop($parts);
+            $parts = array_diff($parts, array('Controller'));
+            $parts[] = $this->deriveControllerClass($controller);
+            $controller = implode(self::HANDLE_SEPARATOR, $parts);
+            $actionHandle = trim($map . $controller, self::HANDLE_SEPARATOR);
+            
+            return $this->inflectName($actionHandle);
+        }
+        return false;
+    }
+    
+    /**
+     * Inflect a name to a normalized value.
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function inflectName($name)
+    {
+        if (!$this->inflector) {
+            $this->inflector = new CamelCaseToDash();
+        }
+        $name = $this->inflector->filter($name);
+        return strtolower($name);
+    }
+    
+    /**
+     * Determine the top-level namespace of the controller.
+     *
+     * @param string $controller
+     * @return string
+     */
+    protected function deriveModuleNamespace($controller)
+    {
+        if (!strstr($controller, '\\')) {
+            return '';
+        }
+        $module = substr($controller, 0, strpos($controller, '\\'));
+        return $module;
+    }
+    
+    /**
+     * Determine the sub-namespace of the controller.
+     *
+     * @param string $namespace
+     * @return string
+     */
+    protected function deriveControllerSubNamespace($namespace)
+    {
+        if (!strstr($namespace, '\\')) {
+            return '';
+        }
+        
+        $nsArray = explode('\\', $namespace);
+        $subNsArray = array_slice($nsArray, 2);
+        
+        if (empty($subNsArray)) {
+            return '';
+        }
+        return implode(self::HANDLE_SEPARATOR, $subNsArray);
+    }
+    
+    /**
+     * Determine the name of the controller, stripping the namespace, and the suffix "Controller" if present.
+     *
+     * @param string $controller
+     * @return string
+     */
+    protected function deriveControllerClass($controller)
+    {
+        if (strstr($controller, '\\')) {
+            $controller = substr($controller, strrpos($controller, '\\') + 1);
+        }
+        
+        if ((10 < strlen($controller))
+            && ('Controller' == substr($controller, -10))
+        ) {
+            $controller = substr($controller, 0, -10);
+        }
+        
+        return $controller;
     }
 }

--- a/src/ConLayout/Listener/ActionHandlesListener.php
+++ b/src/ConLayout/Listener/ActionHandlesListener.php
@@ -23,9 +23,9 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
     use ServiceLocatorAwareTrait;
     
     /**
-     * Character used to separate parts of a controller name.
+     * Character used to separate parts of a template name.
      */
-    const HANDLE_SEPARATOR = '-';
+    const TEMPLATE_SEPARATOR = '/';
     
     /**
      * Layout updater instance.
@@ -184,15 +184,15 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
             $controller = $routeMatchController;
         }
         
-        $actionHandle = $this->mapController($controller);
-        if (!$actionHandle) {
+        $template = $this->mapController($controller);
+        if (!$template) {
             $module     = $this->deriveModuleNamespace($controller);
             
             if ($namespace = $routeMatch->getParam(ModuleRouteListener::MODULE_NAMESPACE)) {
                 $controllerSubNs = $this->deriveControllerSubNamespace($namespace);
                 if (!empty($controllerSubNs)) {
                     if (!empty($module)) {
-                        $module .= self::HANDLE_SEPARATOR . $controllerSubNs;
+                        $module .= self::TEMPLATE_SEPARATOR . $controllerSubNs;
                     } else {
                         $module = $controllerSubNs;
                     }
@@ -200,28 +200,28 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
             }
             
             $controller = $this->deriveControllerClass($controller);
-            $actionHandle = $this->inflectName($module);
+            $template = $this->inflectName($module);
             
-            if (!empty($actionHandle)) {
-                $actionHandle .= self::HANDLE_SEPARATOR;
+            if (!empty($template)) {
+                $template .= self::TEMPLATE_SEPARATOR;
             }
-            $actionHandle .= $this->inflectName($controller);
+            $template .= $this->inflectName($controller);
         }
         
         $action = $routeMatch->getParam('action');
         if (null !== $action) {
-            $actionHandle .= self::HANDLE_SEPARATOR . $this->inflectName($action);
+            $template .= self::TEMPLATE_SEPARATOR . $this->inflectName($action);
         }
         
-        $priority = 10;
+        $priority = 0;
         $actionHandles = [];
         $previousHandle = '';
-        $handleParts = explode(self::HANDLE_SEPARATOR, $actionHandle);
+        $templateParts = explode(self::TEMPLATE_SEPARATOR, $template);
         
-        foreach ($handleParts as $index => $name) {
+        foreach ($templateParts as $index => $name) {
             $actionHandles[] = new Handle($previousHandle.$name, $priority);
             $priority += 10;
-            $previousHandle .= $name.self::HANDLE_SEPARATOR;
+            $previousHandle .= $name.self::TEMPLATE_SEPARATOR;
         }
         
         return $actionHandles;
@@ -249,7 +249,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
             $map = '';
             
             if (is_string($replacement)) {
-                $map = rtrim($replacement, self::HANDLE_SEPARATOR) . self::HANDLE_SEPARATOR;
+                $map = rtrim($replacement, self::TEMPLATE_SEPARATOR) . self::TEMPLATE_SEPARATOR;
                 $controller = substr($controller, strlen($namespace) + 1) ?: '';
             }
             
@@ -257,10 +257,10 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
             array_pop($parts);
             $parts = array_diff($parts, array('Controller'));
             $parts[] = $this->deriveControllerClass($controller);
-            $controller = implode(self::HANDLE_SEPARATOR, $parts);
-            $actionHandle = trim($map . $controller, self::HANDLE_SEPARATOR);
+            $controller = implode(self::TEMPLATE_SEPARATOR, $parts);
+            $template = trim($map . $controller, self::TEMPLATE_SEPARATOR);
             
-            return $this->inflectName($actionHandle);
+            return $this->inflectName($template);
         }
         return false;
     }
@@ -313,7 +313,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
         if (empty($subNsArray)) {
             return '';
         }
-        return implode(self::HANDLE_SEPARATOR, $subNsArray);
+        return implode(self::TEMPLATE_SEPARATOR, $subNsArray);
     }
     
     /**

--- a/src/ConLayout/Listener/ActionHandlesListener.php
+++ b/src/ConLayout/Listener/ActionHandlesListener.php
@@ -271,7 +271,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
      * @param string $name
      * @return string
      */
-    protected function inflectName($name)
+    private function inflectName($name)
     {
         if (!$this->inflector) {
             $this->inflector = new CamelCaseToDash();
@@ -286,7 +286,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
      * @param string $controller
      * @return string
      */
-    protected function deriveModuleNamespace($controller)
+    private function deriveModuleNamespace($controller)
     {
         if (!strstr($controller, '\\')) {
             return '';
@@ -301,7 +301,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
      * @param string $namespace
      * @return string
      */
-    protected function deriveControllerSubNamespace($namespace)
+    private function deriveControllerSubNamespace($namespace)
     {
         if (!strstr($namespace, '\\')) {
             return '';
@@ -322,7 +322,7 @@ class ActionHandlesListener implements ListenerAggregateInterface, ServiceLocato
      * @param string $controller
      * @return string
      */
-    protected function deriveControllerClass($controller)
+    private function deriveControllerClass($controller)
     {
         if (strstr($controller, '\\')) {
             $controller = substr($controller, strrpos($controller, '\\') + 1);

--- a/src/ConLayout/Listener/Factory/ActionHandlesListenerFactory.php
+++ b/src/ConLayout/Listener/Factory/ActionHandlesListenerFactory.php
@@ -21,10 +21,12 @@ class ActionHandlesListenerFactory implements FactoryInterface
     {
         /* @var $moduleOptions ModuleOptions */
         $moduleOptions = $serviceLocator->get('ConLayout\Options\ModuleOptions');
-        $actionHandlesListener = new ActionHandlesListener(
-            $serviceLocator->get('ConLayout\Updater\LayoutUpdaterInterface'),
-            $moduleOptions->getExcludeActionHandleSegments()
-        );
+        $updater = $serviceLocator->get('ConLayout\Updater\LayoutUpdaterInterface');
+        $actionHandlesListener = new ActionHandlesListener();
+        $actionHandlesListener->setUpdater($updater);
+        $actionHandlesListener->setControllerMap($moduleOptions->getControllerMap());
+        $actionHandlesListener->setPreferRouteMatchController($moduleOptions->isPreferRouteMatchController());
+        
         return $actionHandlesListener;
     }
 }

--- a/src/ConLayout/Options/ModuleOptions.php
+++ b/src/ConLayout/Options/ModuleOptions.php
@@ -58,32 +58,64 @@ class ModuleOptions extends AbstractOptions
      * @var array
      */
     protected $defaultArea;
-
+    
     /**
+     * Array of controller namespace -> action handle mappings.
      *
      * @var array
      */
-    protected $excludeActionHandleSegments = [
-        'Controller'
-    ];
-
+    protected $controllerMap = [];
+    
     /**
+     * Flag to force the use of the route match controller param.
+     *
+     * @var boolean
+     */
+    protected $preferRouteMatchController = false;
+    
+    /**
+     * Retrieve an array of controller namespace -> action handle mappings.
      *
      * @return array
      */
-    public function getExcludeActionHandleSegments()
+    public function getControllerMap()
     {
-        return $this->excludeActionHandleSegments;
+        return $this->controllerMap;
     }
-
+    
     /**
+     * Set an array of controller namespace -> action handle mappings.
      *
-     * @param array $excludeActionHandleSegments
+     * @param array $controllerMap
      * @return ModuleOptions
      */
-    public function setExcludeActionHandleSegments(array $excludeActionHandleSegments)
+    public function setControllerMap(array $controllerMap)
     {
-        $this->excludeActionHandleSegments = $excludeActionHandleSegments;
+        $this->controllerMap = $controllerMap;
+        
+        return $this;
+    }
+    
+    /**
+     * Whether to force the use of the route match controller param.
+     *
+     * @return boolean
+     */
+    public function isPreferRouteMatchController()
+    {
+        return $this->preferRouteMatchController;
+    }
+    
+    /**
+     * Set whether to force the use of the route match controller param.
+     *
+     * @param boolean $preferRouteMatchController
+     * @return ModuleOptions
+     */
+    public function setPreferRouteMatchController($preferRouteMatchController)
+    {
+        $this->preferRouteMatchController = (boolean) $preferRouteMatchController;
+        
         return $this;
     }
 

--- a/tests/ConLayoutTest/Controller/TestAsset/SampleController.php
+++ b/tests/ConLayoutTest/Controller/TestAsset/SampleController.php
@@ -1,0 +1,20 @@
+<?php
+namespace ConLayoutTest\Controller\TestAsset;
+
+use Zend\Mvc\Controller\AbstractActionController;
+
+class SampleController extends AbstractActionController
+{
+	public function testAction()
+	{
+		return array('content' => 'test');
+	}
+	public function testSomeStrangelySeparatedWordsAction()
+	{
+		return array('content' => 'Test Some Strangely Separated Words');
+	}
+	public function testCircularAction()
+	{
+		return $this->forward()->dispatch('sample', array('action' => 'test-circular'));
+	}
+}

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -32,11 +32,7 @@ class ActionHandlesListenerTest extends AbstractTest
     }
     
     /**
-     * @covers ActionHandlesListener::mapController
-     * @covers ActionHandlesListener::inflectName
-     * @covers ActionHandlesListener::deriveModuleNamespace
-     * @covers ActionHandlesListener::deriveControllerSubNamespace
-     * @covers ActionHandlesListener::deriveControllerClass
+     * @covers ActionHandlesListener::<protected>
      */
     public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch()
     {

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -391,4 +391,22 @@ class ActionHandlesListenerTest extends AbstractTest
         }
         $this->assertTrue($found, 'Listener not found');
     }
+    
+    public function testGetterAndSetters()
+    {
+        $updater = new LayoutUpdater;
+        $this->listener->setUpdater($updater);
+        $this->assertEquals($updater, $this->listener->getUpdater());
+    
+        $controllerMap = [
+            'Some/Name' => true,
+            'Other/Name' => 'string'
+        ];
+        $this->listener->setControllerMap($controllerMap);
+        $this->assertEquals($controllerMap, $this->listener->getControllerMap());
+    
+        $preferRouteMatchController = true;
+        $this->listener->setPreferRouteMatchController($preferRouteMatchController);
+        $this->assertEquals($preferRouteMatchController, $this->listener->isPreferRouteMatchController());
+    }
 }

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -39,7 +39,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'foo',
             'foo-somewhat'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testNormalizesLiteralControllerNameIfNoNamespaceSeparatorPresent()
@@ -49,7 +49,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'somewhat'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testNormalizesNamesToLowercase()
@@ -63,7 +63,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'somewhat.derived-some',
             'somewhat.derived-some-uber',
             'somewhat.derived-some-uber-cool'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch()
@@ -86,7 +86,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'aj-sweet-apple-acres-reports-cider-sales-pinkie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatchHavingSubNamespace()
@@ -109,7 +109,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'aj-sweet-apple-acres-reports-cider-sales-pinkie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie', 
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget()
@@ -130,7 +130,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout-test-test-asset',
             'con-layout-test-test-asset-sample',
             'con-layout-test-test-asset-sample-test'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTargetShouldMatchControllerFromRouteParam()
@@ -141,12 +141,12 @@ class ActionHandlesListenerTest extends AbstractTest
         $moduleRouteListener = new ModuleRouteListener;
         $moduleRouteListener->onRoute($this->event);
         $this->listener->injectActionHandles($this->event);
-        $handles1 = $this->updater->getHandles();
+        $handles1 = $this->listener->getUpdater()->getHandles();
         
         $myController = new SampleController();
         $this->event->setTarget($myController);
         $this->listener->injectActionHandles($this->event);
-        $handles2 = $this->updater->getHandles();
+        $handles2 = $this->listener->getUpdater()->getHandles();
         
         $this->assertEquals($handles1, $handles2);
     }
@@ -163,7 +163,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'mapped-ns-sub',
             'mapped-ns-sub-ns',
             'mapped-ns-sub-ns-sample'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     
         $this->updater = new LayoutUpdater;
         $this->listener = new ActionHandlesListener;
@@ -179,7 +179,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout',
             'con-layout-test',
             'con-layout-test-sample'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testControllerNotMatchedByMapIsNotAffected()
@@ -195,7 +195,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout-test',
             'con-layout-test-sample',
             'con-layout-test-sample-test'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testFullControllerNameMatchIsMapped()
@@ -212,7 +212,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'string',
             'string-value'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testOnlyFullNamespaceMatchIsMapped()
@@ -233,7 +233,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar',
             'foo-matched-bar-baz',
             'foo-matched-bar-baz-index'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testControllerMapMatchedPrefixReplacedByStringValue()
@@ -250,7 +250,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'string_value',
             'string_value-index'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testUsingNamespaceRouteParameterGivesSameResultAsFullControllerParameter()
@@ -258,7 +258,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $controller1 = 'MappedNs\Foo\Controller\Bar\Baz\Sample';
         $this->routeMatch->setParam('controller', $controller1);
         $this->listener->injectActionHandles($this->event);
-        $handles1 = $this->updater->getHandles();
+        $handles1 = $this->listener->getUpdater()->getHandles();
     
         $controller2 = 'MappedNs\Foo\Controller\Bar';
         $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, $controller2);
@@ -266,7 +266,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $moduleRouteListener = new ModuleRouteListener;
         $moduleRouteListener->onRoute($this->event);
         $this->listener->injectActionHandles($this->event);
-        $handles2 = $this->updater->getHandles();
+        $handles2 = $this->listener->getUpdater()->getHandles();
         
         $this->assertEquals($handles1, $handles2);
     }
@@ -291,7 +291,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar-baz',
             'foo-matched-bar-baz-index',
             'foo-matched-bar-baz-index-test'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testControllerMapRuleSetToFalseIsIgnored()
@@ -313,7 +313,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar',
             'foo-matched-bar-index',
             'foo-matched-bar-index-test'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testControllerMapMoreSpecificRuleMatchesFirst()
@@ -344,12 +344,12 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'some',
             'some-sample'
-        ], $this->updater->getHandles());
+        ], $this->listener->getUpdater()->getHandles());
     }
     
     public function testLayoutUpdaterContainsOnlyDefaultHandle()
     {
-        $this->assertEquals(['default'], $this->updater->getHandles());
+        $this->assertEquals(['default'], $this->listener->getUpdater()->getHandles());
     }
     
     public function testListenerAttachesDispatchErrorEventAtExpectedPriority()

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -4,7 +4,10 @@ namespace ConLayoutTest\Listener;
 use ConLayout\Listener\ActionHandlesListener;
 use ConLayout\Updater\LayoutUpdater;
 use ConLayoutTest\AbstractTest;
+use ConLayoutTest\Controller\TestAsset\SampleController;
 use Zend\EventManager\EventManager;
+use Zend\Mvc\ModuleRouteListener;
+use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\Http\RouteMatch;
 /**
  * @package
@@ -12,50 +15,380 @@ use Zend\Mvc\Router\Http\RouteMatch;
  */
 class ActionHandlesListenerTest extends AbstractTest
 {
-    public function testActionHandles()
+    public function setUp()
     {
-        $updater = new LayoutUpdater();
-
-        $this->assertEquals([
-            'default'
-        ], $updater->getHandles());
-
-        $actionHandlesListener = new ActionHandlesListener(
-            $updater
-        );
-        $event = new \Zend\Mvc\MvcEvent();
-        $routeMatch = new RouteMatch([
-            'controller' => 'App\Controller\Index',
-            'action' => 'index'
-        ]);
-        $event->setRouteMatch($routeMatch);
-
-        $actionHandlesListener->addActionHandles($event);
-
+        $controllerMap = [
+            'MappedNs' => true,
+            'ZendTest\MappedNs' => true,
+        ];
+        
+        $this->updater = new LayoutUpdater;
+        $this->listener = new ActionHandlesListener;
+        $this->listener->setUpdater($this->updater);
+        $this->listener->setControllerMap($controllerMap);
+        $this->event = new MvcEvent;
+        $this->routeMatch = new RouteMatch([]);
+        $this->event->setRouteMatch($this->routeMatch);
+    }
+    
+    public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch()
+    {
+        $this->routeMatch->setParam('controller', 'Foo\Controller\SomewhatController');
+        $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'app',
-            'app-index',
-            'app-index-index'
-        ], $updater->getHandles());
-
+            'foo',
+            'foo-somewhat'
+        ], $this->updater->getHandles());
     }
-
-    public function testAttach()
+    
+    public function testNormalizesLiteralControllerNameIfNoNamespaceSeparatorPresent()
     {
-        $eventManager = new EventManager();
-        $listener = new ActionHandlesListener(
-            $this->getMock('ConLayout\Updater\LayoutUpdaterInterface')
-        );
-
-        $listener->attach($eventManager);
-
-        $listeners = $eventManager->getListeners(
-            \Zend\Mvc\MvcEvent::EVENT_DISPATCH
-        );
-
-        foreach ($listeners as $attachedListener) {
-            $this->assertTrue($attachedListener->getCallback()[0] === $listener);
+        $this->routeMatch->setParam('controller', 'SomewhatController');
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'somewhat'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testNormalizesNamesToLowercase()
+    {
+        $this->routeMatch->setParam('controller', 'Somewhat.DerivedController');
+        $this->routeMatch->setParam('action', 'some-UberCool');
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'somewhat.derived',
+            'somewhat.derived-some',
+            'somewhat.derived-some-uber',
+            'somewhat.derived-some-uber-cool'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'Aj\Controller\SweetAppleAcres\Reports');
+        $this->routeMatch->setParam('controller', 'CiderSales');
+        $this->routeMatch->setParam('action', 'PinkiePieRevenue');
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'aj',
+            'aj-sweet',
+            'aj-sweet-apple',
+            'aj-sweet-apple-acres',
+            'aj-sweet-apple-acres-reports',
+            'aj-sweet-apple-acres-reports-cider',
+            'aj-sweet-apple-acres-reports-cider-sales',
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie',
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie',
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatchHavingSubNamespace()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'Aj\Controller\SweetAppleAcres\Reports');
+        $this->routeMatch->setParam('controller', 'Sub\CiderSales');
+        $this->routeMatch->setParam('action', 'PinkiePieRevenue');
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'aj',
+            'aj-sweet',
+            'aj-sweet-apple',
+            'aj-sweet-apple-acres',
+            'aj-sweet-apple-acres-reports',
+            'aj-sweet-apple-acres-reports-cider',
+            'aj-sweet-apple-acres-reports-cider-sales',
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie',
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie', 
+            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'ConLayoutTest\Controller\TestAsset');
+        $this->routeMatch->setParam('action', 'test');
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+        $myController = new SampleController();
+        $this->event->setTarget($myController);;
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'con',
+            'con-layout',
+            'con-layout-test',
+            'con-layout-test-test',
+            'con-layout-test-test-asset',
+            'con-layout-test-test-asset-sample',
+            'con-layout-test-test-asset-sample-test'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTargetShouldMatchControllerFromRouteParam()
+    {
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'ConLayoutTest\Controller');
+        $this->routeMatch->setParam('controller', 'TestAsset\SampleController');
+        $this->routeMatch->setParam('action', 'test');
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+        $this->listener->injectActionHandles($this->event);
+        $handles1 = $this->updater->getHandles();
+        
+        $myController = new SampleController();
+        $this->event->setTarget($myController);
+        $this->listener->injectActionHandles($this->event);
+        $handles2 = $this->updater->getHandles();
+        
+        $this->assertEquals($handles1, $handles2);
+    }
+    
+    public function testControllerMatchedByMapIsInflected1()
+    {
+        $controller = 'MappedNs\SubNs\Controller\Sample';
+        $this->routeMatch->setParam('controller', $controller);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'mapped',
+            'mapped-ns',
+            'mapped-ns-sub',
+            'mapped-ns-sub-ns',
+            'mapped-ns-sub-ns-sample'
+        ], $this->updater->getHandles());
+    
+        $this->updater = new LayoutUpdater;
+        $this->listener = new ActionHandlesListener;
+        $this->listener->setUpdater($this->updater);
+    
+        $this->listener->setControllerMap(['ZendTest' => true]);
+        $myController = new SampleController();
+        $this->event->setTarget($myController);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'con',
+            'con-layout',
+            'con-layout-test',
+            'con-layout-test-sample'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testControllerNotMatchedByMapIsNotAffected()
+    {
+        $this->routeMatch->setParam('action', 'test');
+        $myController = new SampleController();
+        $this->event->setTarget($myController);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'con',
+            'con-layout',
+            'con-layout-test',
+            'con-layout-test-sample',
+            'con-layout-test-sample-test'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testFullControllerNameMatchIsMapped()
+    {
+        $this->listener->setControllerMap([
+            'Foo\Bar\Controller\IndexController' => 'string-value',
+        ]);
+        $controller = 'Foo\Bar\Controller\IndexController';
+        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('string-value', $actionHandle);
+        $this->routeMatch->setParam('controller', $controller);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'string',
+            'string-value'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testOnlyFullNamespaceMatchIsMapped()
+    {
+        $this->listener->setControllerMap([
+            'Foo' => 'foo-matched',
+            'Foo\Bar' => 'foo-bar-matched',
+        ]);
+        $controller = 'Foo\BarBaz\Controller\IndexController';
+        $actionHandle = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched-bar-baz-index', $actionHandle);
+        $this->routeMatch->setParam('controller', $controller);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'foo',
+            'foo-matched',
+            'foo-matched-bar',
+            'foo-matched-bar-baz',
+            'foo-matched-bar-baz-index'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testControllerMapMatchedPrefixReplacedByStringValue()
+    {
+        $this->listener->setControllerMap([
+            'Foo\Bar' => 'string_value',
+        ]);
+        $controller = 'Foo\Bar\Controller\IndexController';
+        $actionHandle = $this->listener->mapController($controller);
+        $this->assertEquals('string_value-index', $actionHandle);
+        $this->routeMatch->setParam('controller', $controller);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'string_value',
+            'string_value-index'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testUsingNamespaceRouteParameterGivesSameResultAsFullControllerParameter()
+    {
+        $controller1 = 'MappedNs\Foo\Controller\Bar\Baz\Sample';
+        $this->routeMatch->setParam('controller', $controller1);
+        $this->listener->injectActionHandles($this->event);
+        $handles1 = $this->updater->getHandles();
+    
+        $controller2 = 'MappedNs\Foo\Controller\Bar';
+        $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, $controller2);
+        $this->routeMatch->setParam('controller', 'Baz\Sample');
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+        $this->listener->injectActionHandles($this->event);
+        $handles2 = $this->updater->getHandles();
+        
+        $this->assertEquals($handles1, $handles2);
+    }
+    
+    public function testControllerMapOnlyFullNamespaceMatches()
+    {
+        $this->listener->setControllerMap([
+            'Foo' => 'foo-matched',
+            'Foo\Bar' => 'foo-bar-matched',
+        ]);
+        $controller = 'Foo\BarBaz\Controller\IndexController';
+        $actionHandle = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched-bar-baz-index', $actionHandle);
+        $this->routeMatch->setParam('controller', $controller);
+        $this->routeMatch->setParam('action', 'test');
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'foo',
+            'foo-matched',
+            'foo-matched-bar',
+            'foo-matched-bar-baz',
+            'foo-matched-bar-baz-index',
+            'foo-matched-bar-baz-index-test'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testControllerMapRuleSetToFalseIsIgnored()
+    {
+        $this->listener->setControllerMap([
+            'Foo' => 'foo-matched',
+            'Foo\Bar' => false,
+        ]);
+        $controller = 'Foo\Bar\Controller\IndexController';
+        $actionHandle = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched-bar-index', $actionHandle);
+        $this->routeMatch->setParam('controller', $controller);
+        $this->routeMatch->setParam('action', 'test');
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'foo',
+            'foo-matched',
+            'foo-matched-bar',
+            'foo-matched-bar-index',
+            'foo-matched-bar-index-test'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testControllerMapMoreSpecificRuleMatchesFirst()
+    {
+        $this->listener->setControllerMap([
+            'Foo'     => true,
+            'Foo\Bar' => 'bar-baz',
+        ]);
+        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('bar-baz-index', $actionHandle);
+        $this->listener->setControllerMap([
+            'Foo\Bar' => 'bar-baz',
+            'Foo'     => true,
+        ]);
+        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('bar-baz-index', $actionHandle);
+    }
+    
+    public function testPrefersRouteMatchController()
+    {
+        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        $this->listener->setPreferRouteMatchController(true);
+        $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
+        $myController = new SampleController();
+        $this->event->setTarget($myController);
+        $this->listener->injectActionHandles($this->event);
+        $this->assertEquals([
+            'default',
+            'some',
+            'some-sample'
+        ], $this->updater->getHandles());
+    }
+    
+    public function testLayoutUpdaterContainsOnlyDefaultHandle()
+    {
+        $this->assertEquals(['default'], $this->updater->getHandles());
+    }
+    
+    public function testListenerAttachesDispatchErrorEventAtExpectedPriority()
+    {
+        $events = new EventManager();
+        $events->attachAggregate($this->listener);
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
+        $expectedCallback = [$this->listener, 'injectErrorHandle'];
+        $expectedPriority = 100;
+        $found            = false;
+        foreach ($listeners as $listener) {
+            $callback = $listener->getCallback();
+            if ($callback === $expectedCallback) {
+                if ($listener->getMetadatum('priority') == $expectedPriority) {
+                    $found = true;
+                    break;
+                }
+            }
         }
+        $this->assertTrue($found, 'Listener not found');
+    }
+    
+    public function testListenerAttachesDispatchEventAtExpectedPriority()
+    {
+        $events = new EventManager();
+        $events->attachAggregate($this->listener);
+        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $expectedCallback = [$this->listener, 'injectActionHandles'];
+        $expectedPriority = 1000;
+        $found            = false;
+        foreach ($listeners as $listener) {
+            $callback = $listener->getCallback();
+            if ($callback === $expectedCallback) {
+                if ($listener->getMetadatum('priority') == $expectedPriority) {
+                    $found = true;
+                    break;
+                }
+            }
+        }
+        $this->assertTrue($found, 'Listener not found');
     }
 }

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -39,7 +39,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'foo',
             'foo-somewhat'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testNormalizesLiteralControllerNameIfNoNamespaceSeparatorPresent()
@@ -49,7 +49,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'somewhat'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testNormalizesNamesToLowercase()
@@ -63,7 +63,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'somewhat.derived-some',
             'somewhat.derived-some-uber',
             'somewhat.derived-some-uber-cool'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch()
@@ -86,7 +86,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'aj-sweet-apple-acres-reports-cider-sales-pinkie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatchHavingSubNamespace()
@@ -109,7 +109,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'aj-sweet-apple-acres-reports-cider-sales-pinkie',
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie', 
             'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget()
@@ -130,7 +130,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout-test-test-asset',
             'con-layout-test-test-asset-sample',
             'con-layout-test-test-asset-sample-test'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTargetShouldMatchControllerFromRouteParam()
@@ -141,12 +141,12 @@ class ActionHandlesListenerTest extends AbstractTest
         $moduleRouteListener = new ModuleRouteListener;
         $moduleRouteListener->onRoute($this->event);
         $this->listener->injectActionHandles($this->event);
-        $handles1 = $this->listener->getUpdater()->getHandles();
+        $handles1 = $this->updater->getHandles();
         
         $myController = new SampleController();
         $this->event->setTarget($myController);
         $this->listener->injectActionHandles($this->event);
-        $handles2 = $this->listener->getUpdater()->getHandles();
+        $handles2 = $this->updater->getHandles();
         
         $this->assertEquals($handles1, $handles2);
     }
@@ -163,7 +163,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'mapped-ns-sub',
             'mapped-ns-sub-ns',
             'mapped-ns-sub-ns-sample'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     
         $this->updater = new LayoutUpdater;
         $this->listener = new ActionHandlesListener;
@@ -179,7 +179,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout',
             'con-layout-test',
             'con-layout-test-sample'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testControllerNotMatchedByMapIsNotAffected()
@@ -195,7 +195,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'con-layout-test',
             'con-layout-test-sample',
             'con-layout-test-sample-test'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testFullControllerNameMatchIsMapped()
@@ -212,7 +212,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'string',
             'string-value'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testOnlyFullNamespaceMatchIsMapped()
@@ -233,7 +233,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar',
             'foo-matched-bar-baz',
             'foo-matched-bar-baz-index'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testControllerMapMatchedPrefixReplacedByStringValue()
@@ -250,7 +250,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'string_value',
             'string_value-index'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testUsingNamespaceRouteParameterGivesSameResultAsFullControllerParameter()
@@ -258,7 +258,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $controller1 = 'MappedNs\Foo\Controller\Bar\Baz\Sample';
         $this->routeMatch->setParam('controller', $controller1);
         $this->listener->injectActionHandles($this->event);
-        $handles1 = $this->listener->getUpdater()->getHandles();
+        $handles1 = $this->updater->getHandles();
     
         $controller2 = 'MappedNs\Foo\Controller\Bar';
         $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, $controller2);
@@ -266,7 +266,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $moduleRouteListener = new ModuleRouteListener;
         $moduleRouteListener->onRoute($this->event);
         $this->listener->injectActionHandles($this->event);
-        $handles2 = $this->listener->getUpdater()->getHandles();
+        $handles2 = $this->updater->getHandles();
         
         $this->assertEquals($handles1, $handles2);
     }
@@ -291,7 +291,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar-baz',
             'foo-matched-bar-baz-index',
             'foo-matched-bar-baz-index-test'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testControllerMapRuleSetToFalseIsIgnored()
@@ -313,7 +313,7 @@ class ActionHandlesListenerTest extends AbstractTest
             'foo-matched-bar',
             'foo-matched-bar-index',
             'foo-matched-bar-index-test'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testControllerMapMoreSpecificRuleMatchesFirst()
@@ -344,12 +344,12 @@ class ActionHandlesListenerTest extends AbstractTest
             'default',
             'some',
             'some-sample'
-        ], $this->listener->getUpdater()->getHandles());
+        ], $this->updater->getHandles());
     }
     
     public function testLayoutUpdaterContainsOnlyDefaultHandle()
     {
-        $this->assertEquals(['default'], $this->listener->getUpdater()->getHandles());
+        $this->assertEquals(['default'], $this->updater->getHandles());
     }
     
     public function testListenerAttachesDispatchErrorEventAtExpectedPriority()

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -31,6 +31,13 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->event->setRouteMatch($this->routeMatch);
     }
     
+    /**
+     * @covers ActionHandlesListener::mapController
+     * @covers ActionHandlesListener::inflectName
+     * @covers ActionHandlesListener::deriveModuleNamespace
+     * @covers ActionHandlesListener::deriveControllerSubNamespace
+     * @covers ActionHandlesListener::deriveControllerClass
+     */
     public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch()
     {
         $this->routeMatch->setParam('controller', 'Foo\Controller\SomewhatController');

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -31,9 +31,6 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->event->setRouteMatch($this->routeMatch);
     }
     
-    /**
-     * @covers ActionHandlesListener::<protected>
-     */
     public function testUsesModuleAndControllerOnlyIfNoActionInRouteMatch()
     {
         $this->routeMatch->setParam('controller', 'Foo\Controller\SomewhatController');

--- a/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
+++ b/tests/ConLayoutTest/Listener/ActionHandlesListenerTest.php
@@ -38,7 +38,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'foo',
-            'foo-somewhat'
+            'foo/somewhat'
         ], $this->updater->getHandles());
     }
     
@@ -60,9 +60,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'somewhat.derived',
-            'somewhat.derived-some',
-            'somewhat.derived-some-uber',
-            'somewhat.derived-some-uber-cool'
+            'somewhat.derived/some-uber-cool'
         ], $this->updater->getHandles());
     }
     
@@ -77,15 +75,10 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'aj',
-            'aj-sweet',
-            'aj-sweet-apple',
-            'aj-sweet-apple-acres',
-            'aj-sweet-apple-acres-reports',
-            'aj-sweet-apple-acres-reports-cider',
-            'aj-sweet-apple-acres-reports-cider-sales',
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie',
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie',
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
+            'aj/sweet-apple-acres',
+            'aj/sweet-apple-acres/reports',
+            'aj/sweet-apple-acres/reports/cider-sales',
+            'aj/sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue'
         ], $this->updater->getHandles());
     }
     
@@ -100,15 +93,10 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'aj',
-            'aj-sweet',
-            'aj-sweet-apple',
-            'aj-sweet-apple-acres',
-            'aj-sweet-apple-acres-reports',
-            'aj-sweet-apple-acres-reports-cider',
-            'aj-sweet-apple-acres-reports-cider-sales',
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie',
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie', 
-            'aj-sweet-apple-acres-reports-cider-sales-pinkie-pie-revenue'
+            'aj/sweet-apple-acres',
+            'aj/sweet-apple-acres/reports',
+            'aj/sweet-apple-acres/reports/cider-sales',
+            'aj/sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue'
         ], $this->updater->getHandles());
     }
     
@@ -123,13 +111,10 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'con',
-            'con-layout',
             'con-layout-test',
-            'con-layout-test-test',
-            'con-layout-test-test-asset',
-            'con-layout-test-test-asset-sample',
-            'con-layout-test-test-asset-sample-test'
+            'con-layout-test/test-asset',
+            'con-layout-test/test-asset/sample',
+            'con-layout-test/test-asset/sample/test'
         ], $this->updater->getHandles());
     }
     
@@ -158,11 +143,9 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'mapped',
             'mapped-ns',
-            'mapped-ns-sub',
-            'mapped-ns-sub-ns',
-            'mapped-ns-sub-ns-sample'
+            'mapped-ns/sub-ns',
+            'mapped-ns/sub-ns/sample'
         ], $this->updater->getHandles());
     
         $this->updater = new LayoutUpdater;
@@ -175,10 +158,8 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'con',
-            'con-layout',
             'con-layout-test',
-            'con-layout-test-sample'
+            'con-layout-test/sample'
         ], $this->updater->getHandles());
     }
     
@@ -190,11 +171,9 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'con',
-            'con-layout',
             'con-layout-test',
-            'con-layout-test-sample',
-            'con-layout-test-sample-test'
+            'con-layout-test/sample',
+            'con-layout-test/sample/test',
         ], $this->updater->getHandles());
     }
     
@@ -204,13 +183,12 @@ class ActionHandlesListenerTest extends AbstractTest
             'Foo\Bar\Controller\IndexController' => 'string-value',
         ]);
         $controller = 'Foo\Bar\Controller\IndexController';
-        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('string-value', $actionHandle);
+        $template = $this->listener->mapController($controller);
+        $this->assertEquals('string-value', $template);
         $this->routeMatch->setParam('controller', $controller);
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'string',
             'string-value'
         ], $this->updater->getHandles());
     }
@@ -222,34 +200,32 @@ class ActionHandlesListenerTest extends AbstractTest
             'Foo\Bar' => 'foo-bar-matched',
         ]);
         $controller = 'Foo\BarBaz\Controller\IndexController';
-        $actionHandle = $this->listener->mapController($controller);
-        $this->assertEquals('foo-matched-bar-baz-index', $actionHandle);
+        $template = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched/bar-baz/index', $template);
         $this->routeMatch->setParam('controller', $controller);
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'foo',
             'foo-matched',
-            'foo-matched-bar',
-            'foo-matched-bar-baz',
-            'foo-matched-bar-baz-index'
+            'foo-matched/bar-baz',
+            'foo-matched/bar-baz/index'
         ], $this->updater->getHandles());
     }
     
     public function testControllerMapMatchedPrefixReplacedByStringValue()
     {
         $this->listener->setControllerMap([
-            'Foo\Bar' => 'string_value',
+            'FooBar' => 'custom-handle',
         ]);
-        $controller = 'Foo\Bar\Controller\IndexController';
-        $actionHandle = $this->listener->mapController($controller);
-        $this->assertEquals('string_value-index', $actionHandle);
+        $controller = 'FooBar\Controller\IndexController';
+        $template = $this->listener->mapController($controller);
+        $this->assertEquals('custom-handle/index', $template);
         $this->routeMatch->setParam('controller', $controller);
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'string_value',
-            'string_value-index'
+            'custom-handle',
+            'custom-handle/index'
         ], $this->updater->getHandles());
     }
     
@@ -278,19 +254,17 @@ class ActionHandlesListenerTest extends AbstractTest
             'Foo\Bar' => 'foo-bar-matched',
         ]);
         $controller = 'Foo\BarBaz\Controller\IndexController';
-        $actionHandle = $this->listener->mapController($controller);
-        $this->assertEquals('foo-matched-bar-baz-index', $actionHandle);
+        $template = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched/bar-baz/index', $template);
         $this->routeMatch->setParam('controller', $controller);
         $this->routeMatch->setParam('action', 'test');
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'foo',
             'foo-matched',
-            'foo-matched-bar',
-            'foo-matched-bar-baz',
-            'foo-matched-bar-baz-index',
-            'foo-matched-bar-baz-index-test'
+            'foo-matched/bar-baz',
+            'foo-matched/bar-baz/index',
+            'foo-matched/bar-baz/index/test'
         ], $this->updater->getHandles());
     }
     
@@ -301,18 +275,17 @@ class ActionHandlesListenerTest extends AbstractTest
             'Foo\Bar' => false,
         ]);
         $controller = 'Foo\Bar\Controller\IndexController';
-        $actionHandle = $this->listener->mapController($controller);
-        $this->assertEquals('foo-matched-bar-index', $actionHandle);
+        $template = $this->listener->mapController($controller);
+        $this->assertEquals('foo-matched/bar/index', $template);
         $this->routeMatch->setParam('controller', $controller);
         $this->routeMatch->setParam('action', 'test');
         $this->listener->injectActionHandles($this->event);
         $this->assertEquals([
             'default',
-            'foo',
             'foo-matched',
-            'foo-matched-bar',
-            'foo-matched-bar-index',
-            'foo-matched-bar-index-test'
+            'foo-matched/bar',
+            'foo-matched/bar/index',
+            'foo-matched/bar/index/test'
         ], $this->updater->getHandles());
     }
     
@@ -322,14 +295,14 @@ class ActionHandlesListenerTest extends AbstractTest
             'Foo'     => true,
             'Foo\Bar' => 'bar-baz',
         ]);
-        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('bar-baz-index', $actionHandle);
+        $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('bar-baz/index', $template);
         $this->listener->setControllerMap([
             'Foo\Bar' => 'bar-baz',
             'Foo'     => true,
         ]);
-        $actionHandle = $this->listener->mapController('Foo\Bar\Controller\IndexController');
-        $this->assertEquals('bar-baz-index', $actionHandle);
+        $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('bar-baz/index', $template);
     }
     
     public function testPrefersRouteMatchController()
@@ -343,7 +316,7 @@ class ActionHandlesListenerTest extends AbstractTest
         $this->assertEquals([
             'default',
             'some',
-            'some-sample'
+            'some/sample'
         ], $this->updater->getHandles());
     }
     

--- a/tests/ConLayoutTest/Options/ModuleOptionsTest.php
+++ b/tests/ConLayoutTest/Options/ModuleOptionsTest.php
@@ -14,7 +14,8 @@ class ModuleOptionsTest extends AbstractTest
     public function testDefaults()
     {
         $moduleOptions = new ModuleOptions();
-        $this->assertInternalType('array', $moduleOptions->getExcludeActionHandleSegments());
+        $this->assertInternalType('array', $moduleOptions->getControllerMap());
+        $this->assertInternalType('boolean', $moduleOptions->isPreferRouteMatchController());
         $this->assertInternalType('array', $moduleOptions->getAssetPreparers());
         $this->assertInternalType('array', $moduleOptions->getViewHelpers());
         $this->assertInternalType('string', $moduleOptions->getCacheBusterInternalBaseDir());
@@ -49,15 +50,17 @@ class ModuleOptionsTest extends AbstractTest
             'class' => 'MyBlock'
         ], $moduleOptions->getBlockDefaults());
 
-        $excludeActionHandleSegments = [
-            'Controller',
-            'Backend'
+        $controllerMap = [
+            'MappedNs' => true,
+            'ZendTest\MappedNs' => true
         ];
-        $moduleOptions->setExcludeActionHandleSegments($excludeActionHandleSegments);
+        $moduleOptions->setControllerMap($controllerMap);
         $this->assertEquals(
-            $excludeActionHandleSegments,
-            $moduleOptions->getExcludeActionHandleSegments()
+            $controllerMap,
+            $moduleOptions->getControllerMap()
         );
+    
+        $this->assertEquals(false, $moduleOptions->isPreferRouteMatchController());
     }
 
     public function testSetLayoutUpdateExtensions()


### PR DESCRIPTION
Hey mate, I apologise for my previous pull request, it was rushed. You'll notice this time around I've covered your previous test cases and then some. There's a few major changes you should be aware of first, encase you're concerned with backwards compatibility.
1. The class `ActionHandlesListenerFactory` no longer has its dependencies injected in the constructor.
2. The module setting `exclude_action_handle_segments` has been removed as it no longer makes sense. See the new settings `controller_map` & `prefer_route_match_controller`.
3. The `ActionHandlesListener` method names `addActionHandles` & `addErrorHandle` have been renamed to `injectActionHandles` & `injectErrorHandle` for clarity.

**Note**: If your check the coding standards against PSR2 and it fails, this is likely caused by "\r\n" line endings which I cannot prevent because I'm developing on Windows. FWIW when I run PHPUnit the test `ConLayoutTest\AssetPreparer\CacheBusterTest::testMd5File` fails, maybe it's because I'm working on Windows? I didn't have time to investigate the reason why.

![Failed Test](http://s21.postimg.org/si8vnha87/conlayout.png)

Cheers,
Adam
